### PR TITLE
fixed QR code sizing on print

### DIFF
--- a/src/badge_templates/summit_1/General Public/40x60/styles/styles_1.less
+++ b/src/badge_templates/summit_1/General Public/40x60/styles/styles_1.less
@@ -161,7 +161,7 @@
 		margin:0;
 		font-family:gothamnarrow-bold,arial,sans-serif;
 		font-weight:bold;
-		font-size:22pt;
+		font-size:6mm;
 		height:auto;
 		filter:alpha(opacity=100);
 		-ms-filter:progid:DXImageTransform.Microsoft.Alpha(Opacity=100);
@@ -211,6 +211,12 @@
 		width: 25mm;
 		left: 12mm;
 	}
+
+	#qrcode canvas {
+		height: 25mm!important;
+		width: 25mm!important;
+	}
+
 
 	.icon-access {
 		top: 12mm;


### PR DESCRIPTION
Specified 25mm x 25mm for #qrcode canvas