### PR TITLE
Removes hard redirects from error page.

### DIFF
--- a/src/pages/error-page.js
+++ b/src/pages/error-page.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import {connect} from "react-redux";
-import history from '../history';
 
 class ErrorPage extends React.Component {
 

--- a/src/pages/error-page.js
+++ b/src/pages/error-page.js
@@ -1,7 +1,15 @@
 import React from 'react';
 import {connect} from "react-redux";
+import history from '../history';
 
 class ErrorPage extends React.Component {
+
+    onLinkClick = (e) => {
+        if (this.props.onLinkClick) {
+            e.preventDefault();
+            this.props.onLinkClick();
+        }
+    }
 
     render(){
         const { summit } = this.props;
@@ -15,7 +23,7 @@ class ErrorPage extends React.Component {
                 <h1>{title}</h1>
                 <p>{message}</p>
                 <br/>
-                <a className="go-back" href={`/check-in/${path}`}>{linkText}</a>
+                <a href={`/check-in/${path}`} className="go-back" onClick={this.onLinkClick}>{linkText}</a>
             </div>
         );
     }

--- a/src/pages/find-ticket-page.js
+++ b/src/pages/find-ticket-page.js
@@ -17,10 +17,10 @@ class FindTicketPage extends React.Component {
         super(props);
 
         this.state = {
-            embedded    : window.embedded !== undefined,
-            showQRreader: false,
-            notFound    : null,
-            error       : '',
+            embedded      : window.embedded !== undefined,
+            showQRreader  : false,
+            showErrorPage : false,
+            error         : '',
         };
 
     }
@@ -71,7 +71,7 @@ class FindTicketPage extends React.Component {
                     } else if (data.length > 1) {
                         history.push(`${match.url}/tickets`);
                     } else {
-                        this.setState({notFound: true});
+                        this.setState({showErrorPage: true})
                     }
                 }
             );
@@ -92,7 +92,7 @@ class FindTicketPage extends React.Component {
                     } else if (data.length > 1) {
                         history.push(`${match.url}/tickets`);
                     } else {
-                        this.setState({notFound: true});
+                        this.setState({showErrorPage: true})
                     }
                 }
             );
@@ -112,15 +112,16 @@ class FindTicketPage extends React.Component {
     };
     
     render(){
-        const { embedded, showQRreader, error, notFound } = this.state;
+        const { embedded, showQRreader, showErrorPage, error } = this.state;
         const { searchTerm } = this.props;
 
-        if (notFound) {
+        if (showErrorPage) {
             return (
                 <ErrorPage
                     title={T.translate("find_ticket.not_found")}
                     message={T.translate("find_ticket.not_found_message", {search_term: searchTerm})}
                     linkText={T.translate("find_ticket.try_again")}
+                    onLinkClick={() => this.setState({showErrorPage: false})}
                 />
             );
         }

--- a/src/pages/print-page.js
+++ b/src/pages/print-page.js
@@ -63,17 +63,23 @@ class PrintPage extends React.Component {
         };
     };
 
+    goToFindTicketPage = () => {
+        const { summitSlug } = this.props;
+        const path = summitSlug || ''
+        history.push(`/check-in/${path}`);
+    };
+
     render(){
         let { badge, match, location, loading, summitSlug } = this.props;
 
         if (loading) return (<div className="loading-badge">{T.translate("preview.loading")}</div>);
 
         if (!match.params.summit_slug || !match.params.ticket_id) {
-            return (<ErrorPage message={T.translate("preview.summit_missing")} />);
+            return (<ErrorPage message={T.translate("preview.summit_missing")} onLinkClick={this.goToFindTicketPage} />);
         }
 
         if (!badge && !loading) {
-            return (<ErrorPage title={T.translate("preview.error_retrieving")} message={T.translate("preview.contact_help")} />);
+            return (<ErrorPage title={T.translate("preview.error_retrieving")} message={T.translate("preview.contact_help")} onLinkClick={this.goToFindTicketPage} />);
         }
 
         let badgeObj = new Badge(badge);


### PR DESCRIPTION
This is necessary because when running embedded, we toggle logout button visibility. 
When a hard redirect occurs, the logout button visibility reset to default.