### PR TITLE
Check for missing document before set marketing settings

### DIFF
--- a/src/utils/methods.js
+++ b/src/utils/methods.js
@@ -1,8 +1,10 @@
 export const setDocumentColors = (data) => {
-    data.forEach(setting => {
-        if (getComputedStyle(document.documentElement).getPropertyValue(`--${setting.key}`)) {
-            document.documentElement.style.setProperty(`--${setting.key}`, setting.value);
-            document.documentElement.style.setProperty(`--${setting.key}50`, `${setting.value}50`);
-        }
-    });
+    if (typeof document !== 'undefined') {
+        data.forEach(setting => {
+            if (getComputedStyle(document.documentElement).getPropertyValue(`--${setting.key}`)) {
+                document.documentElement.style.setProperty(`--${setting.key}`, setting.value);
+                document.documentElement.style.setProperty(`--${setting.key}50`, `${setting.value}50`);
+            }
+        });
+    }
 };


### PR DESCRIPTION
* Catch missing document before set marketing settings

ref: https://tipit.avaza.com/project/view#!tab=task-pane&groupby=MyTaskProject&view=vertical&task=3373849&stafilter=NotComplete&fileview=grid

Signed-off-by: Tomás Castillo <tcastilloboireau@gmail.com>